### PR TITLE
Switch ddns service to structured JSON logging via slog

### DIFF
--- a/ddns/cloudflare/cloudflare.go
+++ b/ddns/cloudflare/cloudflare.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"time"
 
@@ -40,7 +40,8 @@ func (dc *DnsClient) Info() {
 		},
 	)
 	if err != nil {
-		log.Fatalf("Help: %v", err)
+		slog.Error("failed to list dns records", "err", err)
+		return
 	}
 
 	fmt.Printf("%s", res.JSON.RawJSON())
@@ -66,11 +67,12 @@ func (dc *DnsClient) SetDomainValue(value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to set value: %s, err: %w", value, err)
 	}
-	log.Printf("updated: %s to point to: %s, it took: %fs", dc.dnsRecordID, ip.String(), after.Sub(before).Seconds())
+	duration := after.Sub(before).Seconds()
+	slog.Info("updated", "record_id", dc.dnsRecordID, "ip", ip.String(), "duration_s", duration)
 
 	moddedTime := res.ModifiedOn
 	if !moddedTime.After(before.Add(-10 * time.Minute)) {
-		log.Printf("Warning: Modded time is too long ago: %fs", before.Sub(moddedTime).Seconds())
+		slog.Warn("modified timestamp is too old", "modified_on", moddedTime, "age_s", before.Sub(moddedTime).Seconds())
 	}
 	return nil
 }

--- a/ddns/ddns/ddns.go
+++ b/ddns/ddns/ddns.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/netip"
@@ -36,27 +36,27 @@ func Run(conf config) {
 		// Get public ip address
 		myPublicIP, err := conf.PublicIPResolver()
 		if err != nil {
-			log.Fatalf("Failed to get my public ip: %s", err)
+			slog.Error("failed to get public ip", "err", err)
 			return
 		}
 
 		// Check pub ip if it differs from current
 		currentDNSIP, err := conf.DnsResolver(conf.Domain)
 		if err != nil {
-			log.Fatalf("Failed to lookup: %s, err: %s", conf.Domain, err)
+			slog.Error("failed to lookup domain", "domain", conf.Domain, "err", err)
 			return
 		}
 
-		log.Printf("Current dns ip: %s", currentDNSIP)
+		slog.Info("checked", "dns_ip", currentDNSIP.String(), "public_ip", myPublicIP.String())
 		if currentDNSIP == myPublicIP {
-			log.Printf("Current ip equals public ip, no change: %s", currentDNSIP)
+			slog.Info("no change", "ip", currentDNSIP.String())
 			return
 		}
 
 		// Set ip for domain
 		err = conf.dnsProviderClient.SetDomainValue(myPublicIP.String())
 		if err != nil {
-			log.Printf("failed to set value: %s", err)
+			slog.Error("failed to set dns value", "err", err)
 			return
 		}
 	})
@@ -73,10 +73,6 @@ func SleepingEventLoop(sleepTime time.Duration, f func()) {
 		time.Sleep(sleepTime)
 	}
 }
-
-// func getPublicIPCustom() (string, error) {
-// 	return "1.1.1.2", nil
-// }
 
 func getPublicFromIPIFY() (netip.Addr, error) {
 	url := "https://api.ipify.org?format=json"

--- a/ddns/runtimes/ddnsCloudflare/main.go
+++ b/ddns/runtimes/ddnsCloudflare/main.go
@@ -1,42 +1,34 @@
 package main
 
 import (
-	_ "embed"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/sander-skjulsvik/tools/ddns/ddns"
 )
 
-var ART string = `
-_____ _    _       _           _ _    
-  / ____| |  (_)     | |         (_) |   
- | (___ | | ___ _   _| |_____   ___| | __
-  \___ \| |/ / | | | | / __\ \ / / | |/ /
-  ____) |   <| | |_| | \__ \\ V /| |   < 
- |_____/|_|\_\ |\__,_|_|___/ \_/ |_|_|\_\
-            _/ |                         
-           |__/
-`
-
-// journalctl --user -xeu ddns-cloudflare.service
 func main() {
-	log.Printf("\n\n %s \n\n", ART)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+
 	token := os.Getenv("TOKEN")
 	if token == "" || token == "TOKEN" {
-		log.Fatalf("\n\nTOKEN: is not set, stopping\n\n")
+		slog.Error("TOKEN is not set, stopping")
+		os.Exit(1)
 	}
 	zoneID := os.Getenv("ZONE_ID")
 	if zoneID == "" || zoneID == "ZONE_ID" {
-		log.Fatalf("\n\nZONE_ID: is not set, stopping\n\n")
+		slog.Error("ZONE_ID is not set, stopping")
+		os.Exit(1)
 	}
 	dnsRecordID := os.Getenv("DNS_RECORD_ID")
 	if dnsRecordID == "" || dnsRecordID == "DNS_RECORD_ID" {
-		log.Fatalf("\n\nDNS_RECORD_ID: is not set, stopping\n\n")
+		slog.Error("DNS_RECORD_ID is not set, stopping")
+		os.Exit(1)
 	}
 	domain := os.Getenv("DOMAIN")
 	if domain == "" || domain == "DOMAIN" {
-		log.Fatalf("\n\nDOMAIN: is not set, stopping\n\n")
+		slog.Error("DOMAIN is not set, stopping")
+		os.Exit(1)
 	}
 	ddns.Run(ddns.NewDefaultCloudflareConfig(
 		token, zoneID, dnsRecordID, domain,


### PR DESCRIPTION
Replaces standard log package with log/slog (JSON handler) for structured log output, making logs easier to query in Loki/Grafana.